### PR TITLE
feat(frontend): initialize the sales data table page and handlers 

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "@radix-ui/react-dialog": "^1.1.1",
         "@radix-ui/react-label": "^2.1.0",
         "@radix-ui/react-popover": "^1.1.1",
+        "@radix-ui/react-scroll-area": "^1.1.0",
         "@radix-ui/react-slot": "^1.1.0",
         "@radix-ui/react-toast": "^1.2.1",
         "@tanstack/react-query": "^5.51.16",
@@ -495,6 +496,12 @@
         "node": ">=14"
       }
     },
+    "node_modules/@radix-ui/number": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.0.tgz",
+      "integrity": "sha512-V3gRzhVNU1ldS5XhAPTom1fOIo4ccrjjJgmE+LI2h/WaFpHmx0MQApT+KZHnx8abG6Avtfcz4WoEciMnpFT3HQ==",
+      "license": "MIT"
+    },
     "node_modules/@radix-ui/primitive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.0.tgz",
@@ -640,6 +647,21 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.0.tgz",
+      "integrity": "sha512-BUuBvgThEiAXh2DWu93XsT+a3aWrGqolGlqqw5VU1kG7p/ZH2cuDlM1sRLNnY3QcBS69UIz2mcKhMxDsdewhjg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -876,6 +898,37 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-slot": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-scroll-area": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.1.0.tgz",
+      "integrity": "sha512-9ArIZ9HWhsrfqS765h+GZuLoxaRHD/j0ZWOWilsCvYTpYJp8XwCqNG7Dt9Nu/TItKOdgLGkOPCodQvDc+UMwYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.0",
+        "@radix-ui/primitive": "1.1.0",
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-context": "1.1.0",
+        "@radix-ui/react-direction": "1.1.0",
+        "@radix-ui/react-presence": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "@radix-ui/react-dialog": "^1.1.1",
     "@radix-ui/react-label": "^2.1.0",
     "@radix-ui/react-popover": "^1.1.1",
+    "@radix-ui/react-scroll-area": "^1.1.0",
     "@radix-ui/react-slot": "^1.1.0",
     "@radix-ui/react-toast": "^1.2.1",
     "@tanstack/react-query": "^5.51.16",

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,15 +1,18 @@
-import FormSales from "@/components/ui/forms/FormSales";
-import { listBarang } from "@/lib/api/barang/fetcher";
-import { listCustomer } from "@/lib/api/customer/fetcher";
+import TableSales from "@/components/ui/tables/TableSales";
+import { listSales } from "@/lib/api/sales/fetcher";
 
 export default async function Home() {
-  const dataBarang = listBarang();
-  const dataCustomer = listCustomer();
-
-  const [barang, customer] = await Promise.all([dataBarang, dataCustomer]);
+  const salesData = await listSales();
   return (
-    <div>
-      <FormSales dataBarang={barang.data} dataCustomer={customer.data} />
+    <div className="w-full flex flex-col gap-4 md:gap-8 px-4 md:px-8 py-2 min-h-svh">
+      <div className="w-full flex flex-col gap-px">
+        <h3 className="font-bold text-lg md:text-xl">Data Transaksi</h3>
+        <p className="text-xs text-neutral-600">
+          Berikut merupakan data transaksi yang tersedia di database
+        </p>
+      </div>
+
+      <TableSales data={salesData.data} />
     </div>
   );
 }

--- a/frontend/src/components/ui/forms/FormSales.tsx
+++ b/frontend/src/components/ui/forms/FormSales.tsx
@@ -27,6 +27,7 @@ import { Calendar } from "../calendar";
 import { Form } from "../form";
 import { Input } from "../input";
 import { Popover, PopoverContent, PopoverTrigger } from "../popover";
+import { ScrollArea } from "../scroll-area";
 import {
   Table,
   TableBody,
@@ -65,19 +66,25 @@ export default function FormSales({ dataBarang, dataCustomer }: IFormSales) {
                     }
                     placeholder="Cari berdasarkan nama atau kode"
                   />
-                  {form.barang.map((barang) => (
-                    <Button
-                      variant="outline"
-                      key={barang.id}
-                      onClick={() => form.handler.salesDetail.add(barang.id)}
-                      className="justify-start"
-                    >
-                      <div className="inline-flex items-center gap-2 justify-start">
-                        <span>{barang.kode}</span>
-                        <span>{barang.nama}</span>
-                      </div>
-                    </Button>
-                  ))}
+                  <ScrollArea className="w-full h-[24svh]">
+                    <div className="w-full flex flex-col gap-2">
+                      {form.barang.map((barang) => (
+                        <Button
+                          variant="outline"
+                          key={barang.id}
+                          onClick={() =>
+                            form.handler.salesDetail.add(barang.id)
+                          }
+                          className="justify-start w-full"
+                        >
+                          <div className="inline-flex items-center gap-2 justify-start">
+                            <span>{barang.kode}</span>
+                            <span>{barang.nama}</span>
+                          </div>
+                        </Button>
+                      ))}
+                    </div>
+                  </ScrollArea>
                 </div>
               </PopoverContent>
             </Popover>
@@ -97,21 +104,29 @@ export default function FormSales({ dataBarang, dataCustomer }: IFormSales) {
                     }
                     placeholder="Cari berdasarkan nama atau kode"
                   />
-                  {form.customer.map((customer) => (
-                    <Button
-                      variant={
-                        state.customerId === customer.id ? "default" : "outline"
-                      }
-                      key={customer.id}
-                      onClick={() => form.handler.chooseCustomer(customer.id)}
-                      className="justify-start"
-                    >
-                      <div className="inline-flex items-center gap-2 justify-start">
-                        <span>{customer.kode}</span>
-                        <span>{customer.name}</span>
-                      </div>
-                    </Button>
-                  ))}
+                  <ScrollArea className="w-full h-[24svh]">
+                    <div className="w-full flex flex-col gap-2">
+                      {form.customer.map((customer) => (
+                        <Button
+                          variant={
+                            state.customerId === customer.id
+                              ? "default"
+                              : "outline"
+                          }
+                          key={customer.id}
+                          onClick={() =>
+                            form.handler.chooseCustomer(customer.id)
+                          }
+                          className="justify-start"
+                        >
+                          <div className="inline-flex items-center gap-2 justify-start">
+                            <span>{customer.kode}</span>
+                            <span>{customer.name}</span>
+                          </div>
+                        </Button>
+                      ))}
+                    </div>
+                  </ScrollArea>
                 </div>
               </PopoverContent>
             </Popover>

--- a/frontend/src/components/ui/forms/FormSales.tsx
+++ b/frontend/src/components/ui/forms/FormSales.tsx
@@ -125,6 +125,9 @@ export default function FormSales({ dataBarang, dataCustomer }: IFormSales) {
                 mode="single"
                 selected={state.date ? new Date(state.date) : undefined}
                 onSelect={(date) => form.handler.selectDate(date)}
+                disabled={(date) =>
+                  date > new Date() || date < new Date("1900-01-01")
+                }
                 initialFocus
               />
             </PopoverContent>

--- a/frontend/src/components/ui/forms/FormSales.tsx
+++ b/frontend/src/components/ui/forms/FormSales.tsx
@@ -43,7 +43,7 @@ interface IFormSales {
 }
 
 export default function FormSales({ dataBarang, dataCustomer }: IFormSales) {
-  const { form, state } = useSales({ dataBarang });
+  const { form, state } = useSales({ dataBarang, dataCustomer });
 
   return (
     <div className="min-h-svh relative">
@@ -58,6 +58,13 @@ export default function FormSales({ dataBarang, dataCustomer }: IFormSales) {
               </PopoverTrigger>
               <PopoverContent>
                 <div className="w-full flex flex-col gap-2">
+                  <Input
+                    type="text"
+                    onChange={(e) =>
+                      form.handler.search("barang", e.target.value)
+                    }
+                    placeholder="Cari berdasarkan nama atau kode"
+                  />
                   {form.barang.map((barang) => (
                     <Button
                       variant="outline"
@@ -83,7 +90,14 @@ export default function FormSales({ dataBarang, dataCustomer }: IFormSales) {
               </PopoverTrigger>
               <PopoverContent>
                 <div className="w-full flex flex-col gap-2">
-                  {dataCustomer.map((customer) => (
+                  <Input
+                    type="text"
+                    onChange={(e) =>
+                      form.handler.search("customer", e.target.value)
+                    }
+                    placeholder="Cari berdasarkan nama atau kode"
+                  />
+                  {form.customer.map((customer) => (
                     <Button
                       variant={
                         state.customerId === customer.id ? "default" : "outline"

--- a/frontend/src/components/ui/header.tsx
+++ b/frontend/src/components/ui/header.tsx
@@ -18,7 +18,7 @@ export default function Header() {
   const isActive = (currentPath: string) => pathname === currentPath;
 
   return (
-    <header className="w-full px-4 md:px-8 py-2 sticky top-0 left-0 justify-between inline-flex items-center bg-white/30 backdrop-blur-sm border-b border-b-input z-50">
+    <header className="w-full px-4 md:px-8 py-2 sticky top-0 left-0 justify-between inline-flex items-center bg-white/70 backdrop-blur-md border-b border-b-input z-50">
       <Link href="/" className="flex flex-col gap-px">
         <h1 className="text-lg md:text-xl font-bold">
           PT. Mitra Sinerji Teknoindo
@@ -40,21 +40,23 @@ export default function Header() {
                 <DrawerTitle>Menu</DrawerTitle>
                 <DrawerDescription>Navigasi Fitur</DrawerDescription>
               </DrawerHeader>
-              <Button asChild variant={isActive("/") ? "default" : "outline"}>
-                <Link href="/">Beranda</Link>
-              </Button>
-              <Button
-                asChild
-                variant={isActive("/barang") ? "default" : "outline"}
-              >
-                <Link href="/barang">Data Barang</Link>
-              </Button>
-              <Button
-                asChild
-                variant={isActive("/customer") ? "default" : "outline"}
-              >
-                <Link href="/customer">Data Customer</Link>
-              </Button>
+              <div className="w-full flex flex-col gap-2 px-4 pb-2">
+                <Button asChild variant={isActive("/") ? "default" : "ghost"}>
+                  <Link href="/">Beranda</Link>
+                </Button>
+                <Button
+                  asChild
+                  variant={isActive("/barang") ? "default" : "ghost"}
+                >
+                  <Link href="/barang">Data Barang</Link>
+                </Button>
+                <Button
+                  asChild
+                  variant={isActive("/customer") ? "default" : "ghost"}
+                >
+                  <Link href="/customer">Data Customer</Link>
+                </Button>
+              </div>
             </DrawerContent>
           </Drawer>
         </div>

--- a/frontend/src/components/ui/scroll-area.tsx
+++ b/frontend/src/components/ui/scroll-area.tsx
@@ -1,0 +1,48 @@
+"use client"
+
+import * as React from "react"
+import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area"
+
+import { cn } from "@/lib/utils"
+
+const ScrollArea = React.forwardRef<
+  React.ElementRef<typeof ScrollAreaPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root>
+>(({ className, children, ...props }, ref) => (
+  <ScrollAreaPrimitive.Root
+    ref={ref}
+    className={cn("relative overflow-hidden", className)}
+    {...props}
+  >
+    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">
+      {children}
+    </ScrollAreaPrimitive.Viewport>
+    <ScrollBar />
+    <ScrollAreaPrimitive.Corner />
+  </ScrollAreaPrimitive.Root>
+))
+ScrollArea.displayName = ScrollAreaPrimitive.Root.displayName
+
+const ScrollBar = React.forwardRef<
+  React.ElementRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>,
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>
+>(({ className, orientation = "vertical", ...props }, ref) => (
+  <ScrollAreaPrimitive.ScrollAreaScrollbar
+    ref={ref}
+    orientation={orientation}
+    className={cn(
+      "flex touch-none select-none transition-colors",
+      orientation === "vertical" &&
+        "h-full w-2.5 border-l border-l-transparent p-[1px]",
+      orientation === "horizontal" &&
+        "h-2.5 flex-col border-t border-t-transparent p-[1px]",
+      className
+    )}
+    {...props}
+  >
+    <ScrollAreaPrimitive.ScrollAreaThumb className="relative flex-1 rounded-full bg-border" />
+  </ScrollAreaPrimitive.ScrollAreaScrollbar>
+))
+ScrollBar.displayName = ScrollAreaPrimitive.ScrollAreaScrollbar.displayName
+
+export { ScrollArea, ScrollBar }

--- a/frontend/src/components/ui/tables/TableSales.tsx
+++ b/frontend/src/components/ui/tables/TableSales.tsx
@@ -1,0 +1,281 @@
+"use client";
+
+import { TSales } from "@/lib/api/sales/definitions";
+import useSalesData from "@/lib/hooks/useSalesData";
+import { cn } from "@/lib/utils";
+import { format } from "date-fns";
+import { CalendarIcon, SortAscIcon, SortDescIcon } from "lucide-react";
+import Link from "next/link";
+import { twMerge } from "tailwind-merge";
+import { Button } from "../button";
+import { Calendar } from "../calendar";
+import { Input } from "../input";
+import { Label } from "../label";
+import { Popover, PopoverContent, PopoverTrigger } from "../popover";
+import {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "../table";
+
+interface ITableSalesProps {
+  data: TSales[];
+}
+
+interface ISortableTableHeaderProps {
+  onClick: () => void;
+  className?: string;
+  children: React.ReactNode;
+}
+
+function SortableTableHeader({
+  children,
+  onClick,
+  className,
+}: ISortableTableHeaderProps) {
+  return (
+    <TableHead className={twMerge("text-center border-r", className)}>
+      <Button variant="ghost" onClick={onClick}>
+        {children}
+      </Button>
+    </TableHead>
+  );
+}
+
+function SortIcon({
+  isActive,
+  order,
+}: {
+  isActive: boolean;
+  order: "asc" | "desc";
+}) {
+  return isActive ? (
+    order === "asc" ? (
+      <SortAscIcon className="w-4 h-4 ml-2" />
+    ) : (
+      <SortDescIcon className="w-4 h-4 ml-2" />
+    )
+  ) : null;
+}
+
+export default function TableSales({ data }: ITableSalesProps) {
+  const sales = useSalesData({ salesData: data });
+
+  return (
+    <div className="w-full flex flex-col gap-4">
+      <div className="w-full grid grid-cols-4 gap-4 md:gap-8">
+        <div className="col-span-4 md:col-span-3 flex flex-col gap-2">
+          <Label htmlFor="search">Cari Transaksi</Label>
+          <Input
+            type="text"
+            id="search"
+            name="search"
+            placeholder="Cari berdasarkan no transaksi atau nama customer"
+            className="w-full"
+            onChange={(e) => sales.handler.search(e.target.value)}
+          />
+        </div>
+
+        <div className="hidden md:inline md:col-span-1 md:self-end">
+          <Button variant="default" asChild className="w-full">
+            <Link href="/sales/create">Tambahkan Transaksi</Link>
+          </Button>
+        </div>
+
+        <div className="col-span-4">
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button
+                id="date"
+                variant={"outline"}
+                className={cn(
+                  "w-full justify-start text-left font-normal",
+                  !sales.state.dates && "text-muted-foreground"
+                )}
+              >
+                <CalendarIcon className="mr-2 h-4 w-4" />
+                {sales.state.dates?.from ? (
+                  sales.state.dates.to ? (
+                    <>
+                      {format(sales.state.dates.from, "LLL dd, y")} -{" "}
+                      {format(sales.state.dates.to, "LLL dd, y")}
+                    </>
+                  ) : (
+                    format(sales.state.dates.from, "LLL dd, y")
+                  )
+                ) : (
+                  <span>Pilih Berdasarkan Rentang Tanggal</span>
+                )}
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent className="w-auto p-0" align="start">
+              <Calendar
+                initialFocus
+                mode="range"
+                defaultMonth={sales.state.dates?.from}
+                selected={sales.state.dates}
+                onSelect={sales.handler.changeDate}
+                numberOfMonths={2}
+              />
+            </PopoverContent>
+          </Popover>
+        </div>
+
+        <div className="col-span-4 inline md:hidden">
+          <Button variant="default" asChild className="w-full">
+            <Link href="/sales/create">Tambahkan Transaksi</Link>
+          </Button>
+        </div>
+      </div>
+
+      <Table>
+        <TableCaption>Data Transaksi</TableCaption>
+        <TableHeader>
+          <TableRow className="border">
+            <TableHead className="text-center border-r">No.</TableHead>
+            <SortableTableHeader
+              className="text-center"
+              onClick={() => sales.handler.sort("kode")}
+            >
+              <span>No Transaksi</span>
+              <SortIcon
+                isActive={sales.state.currentSort.by === "kode"}
+                order={sales.state.currentSort.order}
+              />
+            </SortableTableHeader>
+            <SortableTableHeader
+              className="text-center"
+              onClick={() => sales.handler.sort("tgl")}
+            >
+              <span>Tanggal</span>
+              <SortIcon
+                isActive={sales.state.currentSort.by === "tgl"}
+                order={sales.state.currentSort.order}
+              />
+            </SortableTableHeader>
+            <SortableTableHeader
+              className="text-center"
+              onClick={() => sales.handler.sort("cust")}
+            >
+              <span>Nama Customer</span>
+              <SortIcon
+                isActive={sales.state.currentSort.by === "cust"}
+                order={sales.state.currentSort.order}
+              />
+            </SortableTableHeader>
+            <SortableTableHeader
+              className="text-center"
+              onClick={() => sales.handler.sort("sales_detail")}
+            >
+              <span>Jumlah Barang</span>
+              <SortIcon
+                isActive={sales.state.currentSort.by === "sales_detail"}
+                order={sales.state.currentSort.order}
+              />
+            </SortableTableHeader>
+            <SortableTableHeader
+              className="text-center"
+              onClick={() => sales.handler.sort("subtotal")}
+            >
+              <span>Sub Total</span>
+              <SortIcon
+                isActive={sales.state.currentSort.by === "subtotal"}
+                order={sales.state.currentSort.order}
+              />
+            </SortableTableHeader>
+            <SortableTableHeader
+              className="text-center"
+              onClick={() => sales.handler.sort("diskon")}
+            >
+              <span>Diskon</span>
+              <SortIcon
+                isActive={sales.state.currentSort.by === "diskon"}
+                order={sales.state.currentSort.order}
+              />
+            </SortableTableHeader>
+            <SortableTableHeader
+              className="text-center"
+              onClick={() => sales.handler.sort("ongkir")}
+            >
+              <span>Ongkir</span>
+              <SortIcon
+                isActive={sales.state.currentSort.by === "ongkir"}
+                order={sales.state.currentSort.order}
+              />
+            </SortableTableHeader>
+            <SortableTableHeader
+              className="text-center"
+              onClick={() => sales.handler.sort("total_bayar")}
+            >
+              <span>Total</span>
+              <SortIcon
+                isActive={sales.state.currentSort.by === "total_bayar"}
+                order={sales.state.currentSort.order}
+              />
+            </SortableTableHeader>
+          </TableRow>
+        </TableHeader>
+        <TableBody className="border">
+          {sales.state.data.length < 0 ? (
+            <TableRow>
+              <TableCell
+                colSpan={9}
+                className="text-center text-sm text-neutral-600"
+              >
+                Belum ada data transaksi...
+              </TableCell>
+            </TableRow>
+          ) : (
+            <>
+              {sales.state.data.map((sale, index) => (
+                <TableRow key={sale.id}>
+                  <TableCell className="text-center border-r">
+                    {index + 1}.
+                  </TableCell>
+                  <TableCell className="text-center border-r">
+                    {sale.kode}
+                  </TableCell>
+                  <TableCell className="text-center border-r">
+                    {format(sale.tgl, "dd-MMM-y")}
+                  </TableCell>
+                  <TableCell className="text-left border-r">
+                    {sale.cust.name}
+                  </TableCell>
+                  <TableCell className="text-right border-r">
+                    {sales.handler.calculateTotalBarang(sale)}
+                  </TableCell>
+                  <TableCell className="text-center border-r">
+                    {sales.handler.formatCurrency(sale.subtotal)}
+                  </TableCell>
+                  <TableCell className="text-center border-r">
+                    {sales.handler.formatCurrency(sale.diskon)}
+                  </TableCell>
+                  <TableCell className="text-center border-r">
+                    {sales.handler.formatCurrency(sale.ongkir)}
+                  </TableCell>
+                  <TableCell className="text-center border-r">
+                    {sales.handler.formatCurrency(sale.total_bayar)}
+                  </TableCell>
+                </TableRow>
+              ))}
+
+              <TableRow className="bg-neutral-700 text-neutral-200">
+                <TableCell colSpan={4} />
+                <TableCell colSpan={4} className="text-center font-bold">
+                  Grand Total
+                </TableCell>
+                <TableCell className="text-center font-bold">
+                  {sales.handler.formatCurrency(sales.state.grandTotal)}
+                </TableCell>
+              </TableRow>
+            </>
+          )}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/frontend/src/components/ui/tables/TableSales.tsx
+++ b/frontend/src/components/ui/tables/TableSales.tsx
@@ -17,6 +17,7 @@ import {
   TableBody,
   TableCaption,
   TableCell,
+  TableFooter,
   TableHead,
   TableHeader,
   TableRow,
@@ -220,7 +221,7 @@ export default function TableSales({ data }: ITableSalesProps) {
           </TableRow>
         </TableHeader>
         <TableBody className="border">
-          {sales.state.data.length < 0 ? (
+          {sales.state.data.length < 1 ? (
             <TableRow>
               <TableCell
                 colSpan={9}
@@ -230,51 +231,57 @@ export default function TableSales({ data }: ITableSalesProps) {
               </TableCell>
             </TableRow>
           ) : (
-            <>
-              {sales.state.data.map((sale, index) => (
-                <TableRow key={sale.id}>
-                  <TableCell className="text-center border-r">
-                    {index + 1}.
-                  </TableCell>
-                  <TableCell className="text-center border-r">
-                    {sale.kode}
-                  </TableCell>
-                  <TableCell className="text-center border-r">
-                    {format(sale.tgl, "dd-MMM-y")}
-                  </TableCell>
-                  <TableCell className="text-left border-r">
-                    {sale.cust.name}
-                  </TableCell>
-                  <TableCell className="text-right border-r">
-                    {sales.handler.calculateTotalBarang(sale)}
-                  </TableCell>
-                  <TableCell className="text-center border-r">
-                    {sales.handler.formatCurrency(sale.subtotal)}
-                  </TableCell>
-                  <TableCell className="text-center border-r">
-                    {sales.handler.formatCurrency(sale.diskon)}
-                  </TableCell>
-                  <TableCell className="text-center border-r">
-                    {sales.handler.formatCurrency(sale.ongkir)}
-                  </TableCell>
-                  <TableCell className="text-center border-r">
-                    {sales.handler.formatCurrency(sale.total_bayar)}
-                  </TableCell>
-                </TableRow>
-              ))}
-
-              <TableRow className="bg-neutral-700 text-neutral-200">
-                <TableCell colSpan={4} />
-                <TableCell colSpan={4} className="text-center font-bold">
-                  Grand Total
+            sales.state.data.map((sale, index) => (
+              <TableRow key={sale.id}>
+                <TableCell className="text-center border-r">
+                  {index + 1}.
                 </TableCell>
-                <TableCell className="text-center font-bold">
-                  {sales.handler.formatCurrency(sales.state.grandTotal)}
+                <TableCell className="text-center border-r">
+                  {sale.kode}
+                </TableCell>
+                <TableCell className="text-center border-r">
+                  {format(sale.tgl, "dd-MMM-y")}
+                </TableCell>
+                <TableCell className="text-left border-r">
+                  {sale.cust.name}
+                </TableCell>
+                <TableCell className="text-right border-r">
+                  {sales.handler.calculateTotalBarang(sale)}
+                </TableCell>
+                <TableCell className="text-center border-r">
+                  {sales.handler.formatCurrency(sale.subtotal)}
+                </TableCell>
+                <TableCell className="text-center border-r">
+                  {sales.handler.formatCurrency(sale.diskon)}
+                </TableCell>
+                <TableCell className="text-center border-r">
+                  {sales.handler.formatCurrency(sale.ongkir)}
+                </TableCell>
+                <TableCell className="text-center border-r">
+                  {sales.handler.formatCurrency(sale.total_bayar)}
                 </TableCell>
               </TableRow>
-            </>
+            ))
           )}
         </TableBody>
+
+        <TableFooter>
+          <TableRow className="bg-neutral-950 text-neutral-200 hover:bg-neutral-950">
+            <TableCell />
+            <TableCell className="border-r border-r-neutral-600" />
+            <TableCell className="border-r border-r-neutral-600" />
+            <TableCell className="border-r border-r-neutral-600" />
+            <TableCell
+              colSpan={4}
+              className="text-center font-bold border-r border-r-neutral-600"
+            >
+              Grand Total
+            </TableCell>
+            <TableCell className="text-center font-bold">
+              {sales.handler.formatCurrency(sales.state.grandTotal)}
+            </TableCell>
+          </TableRow>
+        </TableFooter>
       </Table>
     </div>
   );

--- a/frontend/src/lib/api/sales/definitions.ts
+++ b/frontend/src/lib/api/sales/definitions.ts
@@ -34,6 +34,7 @@ export const SalesDto = z.object({
 
 export type TSales = {
   id: number;
+  kode: string;
   tgl: string;
   subtotal: number;
   diskon: number;

--- a/frontend/src/lib/hooks/useSales.ts
+++ b/frontend/src/lib/hooks/useSales.ts
@@ -1,0 +1,291 @@
+"use client";
+
+import { useToast } from "@/components/ui/use-toast";
+import { format } from "date-fns";
+import { useRouter } from "next/navigation";
+import React from "react";
+import { useForm, UseFormReturn } from "react-hook-form";
+import * as z from "zod";
+import { TBarang } from "../api/barang/definitions";
+import { createSales } from "../api/sales/actions";
+import { SalesDto, TSalesDetail } from "../api/sales/definitions";
+
+export type TSalesHook = {
+  state: {
+    submitting: boolean;
+    date: string | undefined;
+    customerId: number | null;
+    total: number;
+    subtotal: number;
+  };
+
+  form: {
+    form: UseFormReturn<z.infer<typeof SalesDto>, any, undefined>;
+    productData: TSalesDetail[];
+
+    barang: TBarang[];
+
+    handler: {
+      salesDetail: {
+        add: (id: number) => void;
+        remove: (id: number) => void;
+
+        discountInput: (discount: string, id: number) => void;
+        quantityInput: (quantity: string, id: number) => void;
+      };
+      formatCurrency: (value: number) => string;
+      chooseCustomer: (id: number) => void;
+      resetForm: () => void;
+      selectDate: (date: Date | undefined) => void;
+
+      submit: (data: z.infer<typeof SalesDto>) => Promise<void>;
+    };
+  };
+};
+
+export function useSales({
+  dataBarang,
+}: {
+  dataBarang?: TBarang[];
+}): TSalesHook {
+  const [productData, setProductData] = React.useState<TSalesDetail[]>([]);
+  const [customerId, setCustomerId] = React.useState<number | null>(null);
+  const [submitting, setSubmitting] = React.useState<boolean>(false);
+  const [date, setDate] = React.useState<string>();
+
+  const { toast } = useToast();
+  const router = useRouter();
+
+  const barangToAdd =
+    dataBarang?.filter(
+      (item) => !productData.find((detail) => detail.barang.id === item.id)
+    ) ?? [];
+
+  const form = useForm<z.infer<typeof SalesDto>>({
+    defaultValues: {
+      subtotal: 0,
+      diskon: 0,
+      ongkir: 0,
+      total_bayar: 0,
+      salesDetail: [],
+    },
+  });
+
+  function calculatePrice(price: number, qty: number) {
+    return price * qty;
+  }
+
+  function addBarang(id: number) {
+    setProductData((prev) => {
+      const barang = dataBarang?.find((item) => item.id === id);
+      if (!barang) return prev;
+
+      const productData: TSalesDetail = {
+        id: prev.length > 0 ? prev[prev.length - 1].id + 1 : 1,
+        barang: barang,
+        qty: 1,
+        diskon_nilai: 0,
+        diskon_pct: 0,
+        harga_diskon: barang.harga,
+        total: barang.harga,
+      };
+
+      return [...prev, productData];
+    });
+  }
+
+  function onDiskonInput(diskonPct: string, salesId: number) {
+    let newDiskon = parseInt(diskonPct);
+    if (newDiskon < 0 || newDiskon > 100) return;
+    if (isNaN(newDiskon)) newDiskon = 0;
+
+    setProductData((prev) => {
+      const current = prev.find((item) => item.id === salesId);
+      if (!current) return prev;
+
+      const diskonNilai = (newDiskon / 100) * current.barang.harga;
+      const hargaDiskon = current.barang.harga - diskonNilai;
+      const total = calculatePrice(hargaDiskon, current.qty);
+
+      return prev.map((item) =>
+        item.id === salesId
+          ? {
+              ...item,
+              diskon_pct: newDiskon,
+              diskon_nilai: diskonNilai,
+              harga_diskon: hargaDiskon,
+              total: total,
+            }
+          : item
+      );
+    });
+  }
+
+  function onQtyInput(qty: string, salesId: number) {
+    let newQty = Number(qty);
+    if (newQty < 0) newQty = 1;
+    if (isNaN(newQty)) newQty = 1;
+
+    setProductData((prev) =>
+      prev.map((item) =>
+        item.id === salesId
+          ? {
+              ...item,
+              qty: newQty,
+              total: calculatePrice(item.harga_diskon, newQty),
+            }
+          : item
+      )
+    );
+  }
+
+  function formatCurrency(raw: number) {
+    return raw.toLocaleString("id-ID", {
+      style: "currency",
+      currency: "IDR",
+    });
+  }
+
+  const calculateTotal = React.useCallback(() => {
+    const salesDiskon = form.watch("diskon");
+    const salesOngkir = form.watch("ongkir");
+    const subtotal = productData.reduce((acc, curr) => acc + curr.total, 0);
+    const totalBayar = subtotal - salesDiskon - salesOngkir;
+
+    return {
+      subtotal: subtotal,
+      total: totalBayar,
+    };
+  }, [form, productData]);
+
+  function chooseCustomer(id: number) {
+    setCustomerId((prev) => (prev === id ? null : id));
+  }
+
+  function onDeleteDetail(id: number) {
+    setProductData((prev) => prev.filter((item) => item.id !== id));
+  }
+
+  function onDateSelect(date?: Date) {
+    const selected = format(date ?? new Date(), "Y-MM-dd");
+
+    setDate(selected);
+  }
+
+  async function onSubmit(data: z.infer<typeof SalesDto>) {
+    setSubmitting(true);
+    const { salesDetail, subtotal, total_bayar, cust_id, tgl, ...sales } = data;
+
+    if (productData.length < 1) {
+      toast({
+        variant: "destructive",
+        title: "Error",
+        description: "Barang tidak boleh kosong.",
+      });
+      setSubmitting(false);
+      return;
+    }
+    if (!customerId) {
+      toast({
+        variant: "destructive",
+        title: "Error",
+        description: "Customer tidak boleh kosong.",
+      });
+      setSubmitting(false);
+      return;
+    }
+    if (!date) {
+      toast({
+        variant: "destructive",
+        title: "Error",
+        description: "Tanggal transaksi tidak boleh kosong.",
+      });
+      setSubmitting(false);
+      return;
+    }
+
+    if (productData.some((item) => item.qty < 1)) {
+      toast({
+        variant: "destructive",
+        title: "Error",
+        description: "Kuantitas barang tidak boleh kurang dari 1.",
+      });
+      setSubmitting(false);
+      return;
+    }
+
+    const salesDetailData: typeof salesDetail = productData.map((item) => ({
+      barang_id: item.barang.id,
+      harga_bandrol: item.barang.harga,
+      qty: item.qty,
+      diskon_nilai: item.diskon_nilai,
+      diskon_pct: item.diskon_pct,
+      harga_diskon: item.harga_diskon,
+      total: item.total,
+    }));
+
+    const newSales: typeof data = {
+      ...sales,
+      subtotal: calculateTotal().subtotal,
+      total_bayar: calculateTotal().total,
+      salesDetail: salesDetailData,
+      cust_id: customerId,
+      tgl: date,
+    };
+
+    const response = await createSales(newSales);
+
+    if (response.status === 201) {
+      toast({
+        title: "Data berhasil disimpan",
+        description: response.message.join(", "),
+      });
+      router.refresh();
+      onReset();
+    } else {
+      toast({
+        variant: "destructive",
+        title: "Gagal menyimpan data",
+        description: response.message.join(", "),
+      });
+    }
+
+    setSubmitting(false);
+  }
+
+  function onReset() {
+    form.reset();
+    setProductData([]);
+    setCustomerId(null);
+    setDate(undefined);
+  }
+
+  return {
+    state: {
+      customerId,
+      date,
+      submitting,
+      total: calculateTotal().total,
+      subtotal: calculateTotal().subtotal,
+    },
+
+    form: {
+      form,
+      productData,
+      barang: barangToAdd,
+      handler: {
+        salesDetail: {
+          add: addBarang,
+          remove: onDeleteDetail,
+          discountInput: onDiskonInput,
+          quantityInput: onQtyInput,
+        },
+        chooseCustomer,
+        formatCurrency,
+        resetForm: onReset,
+        selectDate: onDateSelect,
+        submit: onSubmit,
+      },
+    },
+  };
+}

--- a/frontend/src/lib/hooks/useSalesData.ts
+++ b/frontend/src/lib/hooks/useSalesData.ts
@@ -1,0 +1,142 @@
+"use client";
+
+import { format } from "date-fns";
+import React from "react";
+import { DateRange } from "react-day-picker";
+import { TSales } from "../api/sales/definitions";
+
+export type TSalesDataHook = {
+  state: {
+    data: TSales[];
+    currentSort: TSalesSortOptions;
+    dates: DateRange | undefined;
+    grandTotal: number;
+  };
+
+  handler: {
+    calculateTotalBarang: (sale: TSales) => number;
+    formatCurrency: (raw: number) => string;
+    sort: (by: keyof TSales) => void;
+    search: (data: string) => void;
+    changeDate: (dates: DateRange | undefined) => void;
+  };
+};
+
+export type TSalesSortOptions = {
+  by: keyof TSales;
+  order: "asc" | "desc";
+};
+
+export default function useSalesData({
+  salesData,
+}: {
+  salesData: TSales[];
+}): TSalesDataHook {
+  const [search, setSearch] = React.useState<string>("");
+  const [sortOptions, setSortOptions] = React.useState<TSalesSortOptions>({
+    by: "kode",
+    order: "asc",
+  });
+  const [dates, setDates] = React.useState<DateRange | undefined>({
+    from: undefined,
+    to: undefined,
+  });
+
+  function calculateTotalBarang(sale: TSales) {
+    return sale.sales_detail.map((item) => item.barang).length;
+  }
+
+  function formatCurrency(raw: number) {
+    if (raw === 0) {
+      return "-";
+    }
+
+    return new Intl.NumberFormat("id-ID", {
+      style: "currency",
+      currency: "IDR",
+    }).format(raw);
+  }
+
+  function filteredData() {
+    const sortedData = salesData.sort((a, b) => {
+      if (sortOptions.order === "asc") {
+        if (sortOptions.by === "cust") {
+          return a.cust.name > b.cust.name ? 1 : -1;
+        }
+        if (sortOptions.by === "sales_detail") {
+          return a.sales_detail.length > b.sales_detail.length ? 1 : -1;
+        }
+        return a[sortOptions.by] > b[sortOptions.by] ? 1 : -1;
+      } else {
+        if (sortOptions.by === "cust") {
+          return a.cust.name < b.cust.name ? 1 : -1;
+        }
+        if (sortOptions.by === "sales_detail") {
+          return a.sales_detail.length < b.sales_detail.length ? 1 : -1;
+        }
+        return a[sortOptions.by] < b[sortOptions.by] ? 1 : -1;
+      }
+    });
+    return sortedData.filter((sale) => {
+      if (dates && dates.from && dates.to) {
+        const salesDate = new Date(sale.tgl);
+        const from = new Date(format(dates.from, "y-MM-dd"));
+        const to = new Date(format(dates.to, "y-MM-dd"));
+        return (
+          salesDate >= from &&
+          salesDate <= to &&
+          (sale.kode.toLowerCase().includes(search.toLowerCase()) ||
+            sale.cust.name.toLowerCase().includes(search.toLowerCase()))
+        );
+      }
+
+      return (
+        sale.kode.toLowerCase().includes(search.toLowerCase()) ||
+        sale.cust.name.toLowerCase().includes(search.toLowerCase())
+      );
+    });
+  }
+
+  function onSort(by: keyof TSales) {
+    if (sortOptions.by === by) {
+      setSortOptions({
+        by,
+        order: sortOptions.order === "asc" ? "desc" : "asc",
+      });
+    } else {
+      setSortOptions({
+        by,
+        order: "asc",
+      });
+    }
+  }
+
+  function onSearch(data: string) {
+    setSearch(data);
+  }
+
+  function onDateChange(dates: DateRange | undefined) {
+    setDates(dates);
+  }
+
+  function calculateGrandTotal() {
+    const sales = filteredData();
+    return sales.reduce((acc, curr) => acc + curr.total_bayar, 0);
+  }
+
+  return {
+    state: {
+      data: filteredData(),
+      currentSort: sortOptions,
+      dates,
+      grandTotal: calculateGrandTotal(),
+    },
+    handler: {
+      calculateTotalBarang,
+      formatCurrency,
+      sort: onSort,
+      search: onSearch,
+      changeDate: onDateChange,
+    },
+  };
+}


### PR DESCRIPTION
## 🟢 Finalizing the `Sales` data page and handlers 🟢  

In this PR. I've finished the components, pages and handlers for the `Sales` data. 
This PR also optimizes the UX for `Sales` data entry, such as:
- Making the `customers` and `barang` data popovers scrollable
- Add search input for the `customers` and `barang` data popovers

This PR also has some styling improvements for the headers and drawers.