### PR TITLE
feat(frontend): dashboard page

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -26,6 +26,7 @@
         "react-day-picker": "^8.10.1",
         "react-dom": "^18",
         "react-hook-form": "^7.52.1",
+        "recharts": "^2.12.7",
         "tailwind-merge": "^2.4.0",
         "tailwindcss-animate": "^1.0.7",
         "vaul": "^0.9.1",
@@ -52,6 +53,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.0.tgz",
+      "integrity": "sha512-7dRy4DwXwtzBrPbZflqxnvfxLF8kdZXPkhymtDeFoFqE6ldzjQFgYTtYIFARcLEYDrqfBfYcZt1WqFxRoyC9Rw==",
+      "license": "MIT",
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -1177,6 +1190,69 @@
         "react": "^18.0.0"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
+      "integrity": "sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-P2dlU/q51fkOc/Gfl3Ul9kicV7l+ra934qBFXCFhrZMOL6du1TM0pm1ThYvENukyOn5h9v+yMJ9Fn5JK4QozrQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.8.tgz",
+      "integrity": "sha512-gkK1VVTr5iNiYJ7vWDI+yUFFlszhNMtVeneJ6lUTKPjprsvLLI9/tgEGiXJOnlINJA8FyA88gfnQsHbybVZrYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.6.tgz",
+      "integrity": "sha512-5KKk5aKGu2I+O6SONMYSNflgiP0WfZIQvVUMan50wHsLG1G94JlxEVnCpQARfTtzytuY0p/9PXXZb3I7giofIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.3.tgz",
+      "integrity": "sha512-2p6olUZ4w3s+07q3Tm2dbiMZy5pCDfYwtLXXHUnVzXgQlZ/OyPtUz6OL382BkOuGlLXqfT+wqv8Fw2v8/0geBw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -1956,8 +2032,128 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -2047,6 +2243,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/deep-equal": {
       "version": "2.2.3",
@@ -2166,6 +2368,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
       }
     },
     "node_modules/eastasianwidth": {
@@ -2830,12 +3042,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-equals": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.0.1.tgz",
+      "integrity": "sha512-WF1Wi8PwwSY7/6Kx0vKXtw8RwuSGoM1bvDaJbu7MxDlR1vovZjIAKrnzyrThgAjm6JDTu0fVgWXDlMGspodfoQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/fast-glob": {
       "version": "3.3.2",
@@ -3391,6 +3618,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/invariant": {
@@ -4008,6 +4244,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -4720,7 +4962,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -4817,7 +5058,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-remove-scroll": {
@@ -4867,6 +5107,21 @@
         }
       }
     },
+    "node_modules/react-smooth": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.1.tgz",
+      "integrity": "sha512-OE4hm7XqR0jNOq3Qmk9mFLyd6p2+j6bvbPJ7qlB7+oo0eNcL2l7WQzG6MBnT3EXY6xzkLMUBec3AfewJdA0J8w==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-equals": "^5.0.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-style-singleton": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.1.tgz",
@@ -4890,6 +5145,22 @@
         }
       }
     },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -4909,6 +5180,38 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/recharts": {
+      "version": "2.12.7",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.12.7.tgz",
+      "integrity": "sha512-hlLJMhPQfv4/3NBSAyq3gzGg4h2v69RJh6KU7b3pXYNNAELs9kEoXOjbkxdXpALqKBoVmVptGfLpxdaVYqjmXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.21",
+        "react-is": "^16.10.2",
+        "react-smooth": "^4.0.0",
+        "recharts-scale": "^0.4.4",
+        "tiny-invariant": "^1.3.1",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "license": "MIT",
+      "dependencies": {
+        "decimal.js-light": "^2.4.1"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -4932,6 +5235,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+      "license": "MIT"
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.2",
@@ -5624,6 +5933,12 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -5884,6 +6199,28 @@
       "peerDependencies": {
         "react": "^16.8 || ^17.0 || ^18.0",
         "react-dom": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/which": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,7 @@
     "react-day-picker": "^8.10.1",
     "react-dom": "^18",
     "react-hook-form": "^7.52.1",
+    "recharts": "^2.12.7",
     "tailwind-merge": "^2.4.0",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.1",

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,18 +1,84 @@
-import TableSales from "@/components/ui/tables/TableSales";
-import { listSales } from "@/lib/api/sales/fetcher";
+import { Button } from "@/components/ui/button";
+import SalesChartContainer from "@/components/ui/SalesChartContainer";
+import { listBarang } from "@/lib/api/barang/fetcher";
+import { listCustomer } from "@/lib/api/customer/fetcher";
+import Link from "next/link";
 
 export default async function Home() {
-  const salesData = await listSales();
+  const dataBarang = listBarang();
+  const dataCustomer = listCustomer();
+
+  const [barang, customer] = await Promise.all([dataBarang, dataCustomer]);
+
   return (
-    <div className="w-full flex flex-col gap-4 md:gap-8 px-4 md:px-8 py-2 min-h-svh">
-      <div className="w-full flex flex-col gap-px">
-        <h3 className="font-bold text-lg md:text-xl">Data Transaksi</h3>
-        <p className="text-xs text-neutral-600">
-          Berikut merupakan data transaksi yang tersedia di database
-        </p>
+    <div className="w-full px-4 md:px-8 py-2 min-h-[calc(100svh-4rem)] gap-8 flex flex-col justify-center">
+      <div className="flex flex-col gap-2 items-center">
+        <div className="flex flex-col gap-1 items-center">
+          <Link href="/sales" className="font-bold text-lg underline">
+            Statistik Transaksi
+          </Link>
+          <p className="text-sm text-neutral-600">
+            Berikut merupakan data statistik grand total dari seluruh transaksi
+          </p>
+        </div>
+        <SalesChartContainer />
       </div>
 
-      <TableSales data={salesData.data} />
+      <div className="w-full grid grid-cols-1 md:grid-cols-2 gap-8">
+        <div className="flex flex-col gap-2 items-center p-2 border rounded-md">
+          <div className="flex flex-col gap-1 items-center">
+            <Link href="/barang" className="font-bold text-lg underline">
+              Data Barang
+            </Link>
+            <p className="text-sm text-neutral-600">
+              Berikut merupakan data barang yang tersedia
+            </p>
+          </div>
+          <div className="w-full grid grid-cols-2 gap-4 bg-white rounded-md p-4">
+            {barang.data.length < 1 ? (
+              <p className="text-sm text-neutral-600 col-span-2">
+                Tidak ada data barang yang tersedia...
+              </p>
+            ) : (
+              barang.data.slice(0, 4).map((item) => (
+                <Button asChild key={item.id}>
+                  <Link href={`/barang/${item.id}`}>
+                    <p className="mr-2">{item.kode}</p>
+                    <p>{item.nama}</p>
+                  </Link>
+                </Button>
+              ))
+            )}
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-2 items-center p-2 border rounded-md">
+          <div className="flex flex-col gap-1 items-center">
+            <Link href="/customer" className="font-bold text-lg underline">
+              Data Customer
+            </Link>
+            <p className="text-sm text-neutral-600">
+              Berikut merupakan data customer yang tersedia
+            </p>
+          </div>
+          <div className="w-full grid grid-cols-2 gap-4 bg-white rounded-md p-4">
+            {customer.data.length < 1 ? (
+              <p className="text-sm text-neutral-600 col-span-2">
+                Tidak ada data customer yang tersedia...
+              </p>
+            ) : (
+              customer.data.slice(0, 4).map((item) => (
+                <Button asChild key={item.id}>
+                  <Link href={`/customer/${item.id}`}>
+                    <p className="mr-2">{item.kode}</p>
+                    <p>{item.name}</p>
+                  </Link>
+                </Button>
+              ))
+            )}
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/frontend/src/app/sales/page.tsx
+++ b/frontend/src/app/sales/page.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import TableSales from "@/components/ui/tables/TableSales";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+const queryClient = new QueryClient();
+
+export default function SalesPage() {
+  return (
+    <div className="w-full flex flex-col gap-4 md:gap-8 px-4 md:px-8 py-2 min-h-svh">
+      <div className="w-full flex flex-col gap-px">
+        <h3 className="font-bold text-lg md:text-xl">Data Transaksi</h3>
+        <p className="text-xs text-neutral-600">
+          Berikut merupakan data transaksi yang tersedia di database
+        </p>
+      </div>
+      <QueryClientProvider client={queryClient}>
+        <TableSales />
+      </QueryClientProvider>
+    </div>
+  );
+}

--- a/frontend/src/components/ui/SalesChart.tsx
+++ b/frontend/src/components/ui/SalesChart.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import {
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
+import useChart from "@/lib/hooks/useChart";
+import { Bar, BarChart, CartesianGrid, XAxis } from "recharts";
+
+export default function SalesChart() {
+  const chart = useChart();
+
+  return (
+    <ChartContainer
+      config={chart.config}
+      className="h-[40svh] w-full md:max-w-4xl border rounded-md mx-0 md:mx-auto"
+    >
+      <BarChart accessibilityLayer data={chart.data}>
+        <CartesianGrid vertical={false} />
+        <XAxis
+          dataKey="month"
+          tickLine={false}
+          tickMargin={10}
+          axisLine={false}
+          tickFormatter={(value) => value.slice(0, 3)}
+        />
+        <ChartTooltip content={<ChartTooltipContent hideIndicator />} />
+        <ChartLegend content={<ChartLegendContent />} />
+        {chart.years.map((year) => (
+          <Bar
+            key={year}
+            dataKey={year}
+            fill={chart.config[year].color}
+            radius={4}
+          />
+        ))}
+      </BarChart>
+    </ChartContainer>
+  );
+}

--- a/frontend/src/components/ui/SalesChartContainer.tsx
+++ b/frontend/src/components/ui/SalesChartContainer.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import React from "react";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import SalesChart from "./SalesChart";
+
+const queryClient = new QueryClient();
+
+export default function SalesChartContainer() {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <SalesChart />
+    </QueryClientProvider>
+  );
+}

--- a/frontend/src/components/ui/card.tsx
+++ b/frontend/src/components/ui/card.tsx
@@ -1,0 +1,79 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "rounded-lg border bg-card text-card-foreground shadow-sm",
+      className
+    )}
+    {...props}
+  />
+))
+Card.displayName = "Card"
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    {...props}
+  />
+))
+CardHeader.displayName = "CardHeader"
+
+const CardTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h3
+    ref={ref}
+    className={cn(
+      "text-2xl font-semibold leading-none tracking-tight",
+      className
+    )}
+    {...props}
+  />
+))
+CardTitle.displayName = "CardTitle"
+
+const CardDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+CardDescription.displayName = "CardDescription"
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+))
+CardContent.displayName = "CardContent"
+
+const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex items-center p-6 pt-0", className)}
+    {...props}
+  />
+))
+CardFooter.displayName = "CardFooter"
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }

--- a/frontend/src/components/ui/chart.tsx
+++ b/frontend/src/components/ui/chart.tsx
@@ -1,0 +1,365 @@
+"use client"
+
+import * as React from "react"
+import * as RechartsPrimitive from "recharts"
+
+import { cn } from "@/lib/utils"
+
+// Format: { THEME_NAME: CSS_SELECTOR }
+const THEMES = { light: "", dark: ".dark" } as const
+
+export type ChartConfig = {
+  [k in string]: {
+    label?: React.ReactNode
+    icon?: React.ComponentType
+  } & (
+    | { color?: string; theme?: never }
+    | { color?: never; theme: Record<keyof typeof THEMES, string> }
+  )
+}
+
+type ChartContextProps = {
+  config: ChartConfig
+}
+
+const ChartContext = React.createContext<ChartContextProps | null>(null)
+
+function useChart() {
+  const context = React.useContext(ChartContext)
+
+  if (!context) {
+    throw new Error("useChart must be used within a <ChartContainer />")
+  }
+
+  return context
+}
+
+const ChartContainer = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentProps<"div"> & {
+    config: ChartConfig
+    children: React.ComponentProps<
+      typeof RechartsPrimitive.ResponsiveContainer
+    >["children"]
+  }
+>(({ id, className, children, config, ...props }, ref) => {
+  const uniqueId = React.useId()
+  const chartId = `chart-${id || uniqueId.replace(/:/g, "")}`
+
+  return (
+    <ChartContext.Provider value={{ config }}>
+      <div
+        data-chart={chartId}
+        ref={ref}
+        className={cn(
+          "flex aspect-video justify-center text-xs [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-none [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-sector]:outline-none [&_.recharts-surface]:outline-none",
+          className
+        )}
+        {...props}
+      >
+        <ChartStyle id={chartId} config={config} />
+        <RechartsPrimitive.ResponsiveContainer>
+          {children}
+        </RechartsPrimitive.ResponsiveContainer>
+      </div>
+    </ChartContext.Provider>
+  )
+})
+ChartContainer.displayName = "Chart"
+
+const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
+  const colorConfig = Object.entries(config).filter(
+    ([_, config]) => config.theme || config.color
+  )
+
+  if (!colorConfig.length) {
+    return null
+  }
+
+  return (
+    <style
+      dangerouslySetInnerHTML={{
+        __html: Object.entries(THEMES)
+          .map(
+            ([theme, prefix]) => `
+${prefix} [data-chart=${id}] {
+${colorConfig
+  .map(([key, itemConfig]) => {
+    const color =
+      itemConfig.theme?.[theme as keyof typeof itemConfig.theme] ||
+      itemConfig.color
+    return color ? `  --color-${key}: ${color};` : null
+  })
+  .join("\n")}
+}
+`
+          )
+          .join("\n"),
+      }}
+    />
+  )
+}
+
+const ChartTooltip = RechartsPrimitive.Tooltip
+
+const ChartTooltipContent = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentProps<typeof RechartsPrimitive.Tooltip> &
+    React.ComponentProps<"div"> & {
+      hideLabel?: boolean
+      hideIndicator?: boolean
+      indicator?: "line" | "dot" | "dashed"
+      nameKey?: string
+      labelKey?: string
+    }
+>(
+  (
+    {
+      active,
+      payload,
+      className,
+      indicator = "dot",
+      hideLabel = false,
+      hideIndicator = false,
+      label,
+      labelFormatter,
+      labelClassName,
+      formatter,
+      color,
+      nameKey,
+      labelKey,
+    },
+    ref
+  ) => {
+    const { config } = useChart()
+
+    const tooltipLabel = React.useMemo(() => {
+      if (hideLabel || !payload?.length) {
+        return null
+      }
+
+      const [item] = payload
+      const key = `${labelKey || item.dataKey || item.name || "value"}`
+      const itemConfig = getPayloadConfigFromPayload(config, item, key)
+      const value =
+        !labelKey && typeof label === "string"
+          ? config[label as keyof typeof config]?.label || label
+          : itemConfig?.label
+
+      if (labelFormatter) {
+        return (
+          <div className={cn("font-medium", labelClassName)}>
+            {labelFormatter(value, payload)}
+          </div>
+        )
+      }
+
+      if (!value) {
+        return null
+      }
+
+      return <div className={cn("font-medium", labelClassName)}>{value}</div>
+    }, [
+      label,
+      labelFormatter,
+      payload,
+      hideLabel,
+      labelClassName,
+      config,
+      labelKey,
+    ])
+
+    if (!active || !payload?.length) {
+      return null
+    }
+
+    const nestLabel = payload.length === 1 && indicator !== "dot"
+
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          "grid min-w-[8rem] items-start gap-1.5 rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl",
+          className
+        )}
+      >
+        {!nestLabel ? tooltipLabel : null}
+        <div className="grid gap-1.5">
+          {payload.map((item, index) => {
+            const key = `${nameKey || item.name || item.dataKey || "value"}`
+            const itemConfig = getPayloadConfigFromPayload(config, item, key)
+            const indicatorColor = color || item.payload.fill || item.color
+
+            return (
+              <div
+                key={item.dataKey}
+                className={cn(
+                  "flex w-full flex-wrap items-stretch gap-2 [&>svg]:h-2.5 [&>svg]:w-2.5 [&>svg]:text-muted-foreground",
+                  indicator === "dot" && "items-center"
+                )}
+              >
+                {formatter && item?.value !== undefined && item.name ? (
+                  formatter(item.value, item.name, item, index, item.payload)
+                ) : (
+                  <>
+                    {itemConfig?.icon ? (
+                      <itemConfig.icon />
+                    ) : (
+                      !hideIndicator && (
+                        <div
+                          className={cn(
+                            "shrink-0 rounded-[2px] border-[--color-border] bg-[--color-bg]",
+                            {
+                              "h-2.5 w-2.5": indicator === "dot",
+                              "w-1": indicator === "line",
+                              "w-0 border-[1.5px] border-dashed bg-transparent":
+                                indicator === "dashed",
+                              "my-0.5": nestLabel && indicator === "dashed",
+                            }
+                          )}
+                          style={
+                            {
+                              "--color-bg": indicatorColor,
+                              "--color-border": indicatorColor,
+                            } as React.CSSProperties
+                          }
+                        />
+                      )
+                    )}
+                    <div
+                      className={cn(
+                        "flex flex-1 justify-between leading-none",
+                        nestLabel ? "items-end" : "items-center"
+                      )}
+                    >
+                      <div className="grid gap-1.5">
+                        {nestLabel ? tooltipLabel : null}
+                        <span className="text-muted-foreground">
+                          {itemConfig?.label || item.name}
+                        </span>
+                      </div>
+                      {item.value && (
+                        <span className="font-mono font-medium tabular-nums text-foreground">
+                          {item.value.toLocaleString()}
+                        </span>
+                      )}
+                    </div>
+                  </>
+                )}
+              </div>
+            )
+          })}
+        </div>
+      </div>
+    )
+  }
+)
+ChartTooltipContent.displayName = "ChartTooltip"
+
+const ChartLegend = RechartsPrimitive.Legend
+
+const ChartLegendContent = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentProps<"div"> &
+    Pick<RechartsPrimitive.LegendProps, "payload" | "verticalAlign"> & {
+      hideIcon?: boolean
+      nameKey?: string
+    }
+>(
+  (
+    { className, hideIcon = false, payload, verticalAlign = "bottom", nameKey },
+    ref
+  ) => {
+    const { config } = useChart()
+
+    if (!payload?.length) {
+      return null
+    }
+
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          "flex items-center justify-center gap-4",
+          verticalAlign === "top" ? "pb-3" : "pt-3",
+          className
+        )}
+      >
+        {payload.map((item) => {
+          const key = `${nameKey || item.dataKey || "value"}`
+          const itemConfig = getPayloadConfigFromPayload(config, item, key)
+
+          return (
+            <div
+              key={item.value}
+              className={cn(
+                "flex items-center gap-1.5 [&>svg]:h-3 [&>svg]:w-3 [&>svg]:text-muted-foreground"
+              )}
+            >
+              {itemConfig?.icon && !hideIcon ? (
+                <itemConfig.icon />
+              ) : (
+                <div
+                  className="h-2 w-2 shrink-0 rounded-[2px]"
+                  style={{
+                    backgroundColor: item.color,
+                  }}
+                />
+              )}
+              {itemConfig?.label}
+            </div>
+          )
+        })}
+      </div>
+    )
+  }
+)
+ChartLegendContent.displayName = "ChartLegend"
+
+// Helper to extract item config from a payload.
+function getPayloadConfigFromPayload(
+  config: ChartConfig,
+  payload: unknown,
+  key: string
+) {
+  if (typeof payload !== "object" || payload === null) {
+    return undefined
+  }
+
+  const payloadPayload =
+    "payload" in payload &&
+    typeof payload.payload === "object" &&
+    payload.payload !== null
+      ? payload.payload
+      : undefined
+
+  let configLabelKey: string = key
+
+  if (
+    key in payload &&
+    typeof payload[key as keyof typeof payload] === "string"
+  ) {
+    configLabelKey = payload[key as keyof typeof payload] as string
+  } else if (
+    payloadPayload &&
+    key in payloadPayload &&
+    typeof payloadPayload[key as keyof typeof payloadPayload] === "string"
+  ) {
+    configLabelKey = payloadPayload[
+      key as keyof typeof payloadPayload
+    ] as string
+  }
+
+  return configLabelKey in config
+    ? config[configLabelKey]
+    : config[key as keyof typeof config]
+}
+
+export {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  ChartLegend,
+  ChartLegendContent,
+  ChartStyle,
+}

--- a/frontend/src/components/ui/header.tsx
+++ b/frontend/src/components/ui/header.tsx
@@ -44,6 +44,9 @@ export default function Header() {
                 <Button asChild variant={isActive("/") ? "default" : "ghost"}>
                   <Link href="/">Beranda</Link>
                 </Button>
+                <Button asChild variant={isActive("/") ? "default" : "ghost"}>
+                  <Link href="/sales">Data Transaksi</Link>
+                </Button>
                 <Button
                   asChild
                   variant={isActive("/barang") ? "default" : "ghost"}
@@ -64,6 +67,9 @@ export default function Header() {
         <div className="hidden md:inline-flex gap-4">
           <Button asChild variant={isActive("/") ? "default" : "link"}>
             <Link href="/">Beranda</Link>
+          </Button>
+          <Button asChild variant={isActive("/sales") ? "default" : "link"}>
+            <Link href="/sales">Data Transaksi</Link>
           </Button>
           <Button asChild variant={isActive("/barang") ? "default" : "link"}>
             <Link href="/barang">Data Barang</Link>

--- a/frontend/src/components/ui/header.tsx
+++ b/frontend/src/components/ui/header.tsx
@@ -42,7 +42,7 @@ export default function Header() {
               </DrawerHeader>
               <div className="w-full flex flex-col gap-2 px-4 pb-2">
                 <Button asChild variant={isActive("/") ? "default" : "ghost"}>
-                  <Link href="/">Beranda</Link>
+                  <Link href="/">Dashboard</Link>
                 </Button>
                 <Button asChild variant={isActive("/") ? "default" : "ghost"}>
                   <Link href="/sales">Data Transaksi</Link>
@@ -66,7 +66,7 @@ export default function Header() {
 
         <div className="hidden md:inline-flex gap-4">
           <Button asChild variant={isActive("/") ? "default" : "link"}>
-            <Link href="/">Beranda</Link>
+            <Link href="/">Dashboard</Link>
           </Button>
           <Button asChild variant={isActive("/sales") ? "default" : "link"}>
             <Link href="/sales">Data Transaksi</Link>

--- a/frontend/src/components/ui/tables/TableSales.tsx
+++ b/frontend/src/components/ui/tables/TableSales.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { TSales } from "@/lib/api/sales/definitions";
 import useSalesData from "@/lib/hooks/useSalesData";
 import { cn } from "@/lib/utils";
 import { format } from "date-fns";
@@ -22,10 +21,7 @@ import {
   TableHeader,
   TableRow,
 } from "../table";
-
-interface ITableSalesProps {
-  data: TSales[];
-}
+import TableSkeleton from "./TableSkeleton";
 
 interface ISortableTableHeaderProps {
   onClick: () => void;
@@ -63,8 +59,8 @@ function SortIcon({
   ) : null;
 }
 
-export default function TableSales({ data }: ITableSalesProps) {
-  const sales = useSalesData({ salesData: data });
+export default function TableSales() {
+  const sales = useSalesData();
 
   return (
     <div className="w-full flex flex-col gap-4">
@@ -220,48 +216,71 @@ export default function TableSales({ data }: ITableSalesProps) {
             </SortableTableHeader>
           </TableRow>
         </TableHeader>
+
         <TableBody className="border">
-          {sales.state.data.length < 1 ? (
+          {!sales.state.isLoading && !sales.state.error ? (
+            sales.state.data.length < 1 ? (
+              <TableRow>
+                <TableCell
+                  colSpan={9}
+                  className="text-center text-sm text-neutral-600"
+                >
+                  Belum ada data transaksi...
+                </TableCell>
+              </TableRow>
+            ) : (
+              sales.state.data.map((sale, index) => (
+                <TableRow key={sale.id}>
+                  <TableCell className="text-center border-r">
+                    {index + 1}.
+                  </TableCell>
+                  <TableCell className="text-center border-r">
+                    {sale.kode}
+                  </TableCell>
+                  <TableCell className="text-center border-r">
+                    {format(sale.tgl, "dd-MMM-y")}
+                  </TableCell>
+                  <TableCell className="text-left border-r">
+                    {sale.cust.name}
+                  </TableCell>
+                  <TableCell className="text-right border-r">
+                    {sales.handler.calculateTotalBarang(sale)}
+                  </TableCell>
+                  <TableCell className="text-center border-r">
+                    {sales.handler.formatCurrency(sale.subtotal)}
+                  </TableCell>
+                  <TableCell className="text-center border-r">
+                    {sales.handler.formatCurrency(sale.diskon)}
+                  </TableCell>
+                  <TableCell className="text-center border-r">
+                    {sales.handler.formatCurrency(sale.ongkir)}
+                  </TableCell>
+                  <TableCell className="text-center border-r">
+                    {sales.handler.formatCurrency(sale.total_bayar)}
+                  </TableCell>
+                </TableRow>
+              ))
+            )
+          ) : sales.state.isLoading ? (
+            <TableSkeleton rows={9} />
+          ) : sales.state.error ? (
             <TableRow>
               <TableCell
                 colSpan={9}
                 className="text-center text-sm text-neutral-600"
               >
-                Belum ada data transaksi...
+                Terjadi kesalahan saat memuat data transaksi...
               </TableCell>
             </TableRow>
           ) : (
-            sales.state.data.map((sale, index) => (
-              <TableRow key={sale.id}>
-                <TableCell className="text-center border-r">
-                  {index + 1}.
-                </TableCell>
-                <TableCell className="text-center border-r">
-                  {sale.kode}
-                </TableCell>
-                <TableCell className="text-center border-r">
-                  {format(sale.tgl, "dd-MMM-y")}
-                </TableCell>
-                <TableCell className="text-left border-r">
-                  {sale.cust.name}
-                </TableCell>
-                <TableCell className="text-right border-r">
-                  {sales.handler.calculateTotalBarang(sale)}
-                </TableCell>
-                <TableCell className="text-center border-r">
-                  {sales.handler.formatCurrency(sale.subtotal)}
-                </TableCell>
-                <TableCell className="text-center border-r">
-                  {sales.handler.formatCurrency(sale.diskon)}
-                </TableCell>
-                <TableCell className="text-center border-r">
-                  {sales.handler.formatCurrency(sale.ongkir)}
-                </TableCell>
-                <TableCell className="text-center border-r">
-                  {sales.handler.formatCurrency(sale.total_bayar)}
-                </TableCell>
-              </TableRow>
-            ))
+            <TableRow>
+              <TableCell
+                colSpan={9}
+                className="text-center text-sm text-neutral-600"
+              >
+                Terjadi kesalahan saat memuat data transaksi...
+              </TableCell>
+            </TableRow>
           )}
         </TableBody>
 

--- a/frontend/src/lib/api/sales/fetcher.ts
+++ b/frontend/src/lib/api/sales/fetcher.ts
@@ -9,7 +9,9 @@ export async function listSales(): Promise<TListSalesApiResponse> {
 }
 
 export async function getSalesById(id: number): Promise<TGetSalesApiResponse> {
-  const res = await fetch(ApiEndpoint.Sales.Detail(id));
+  const res = await fetch(ApiEndpoint.Sales.Detail(id), {
+    cache: "no-store",
+  });
   const response: TGetSalesApiResponse = await res.json();
 
   return response;

--- a/frontend/src/lib/hooks/useChart.ts
+++ b/frontend/src/lib/hooks/useChart.ts
@@ -1,0 +1,137 @@
+"use client";
+
+import { ChartConfig } from "@/components/ui/chart";
+import { useQuery } from "@tanstack/react-query";
+import { listSales } from "../api/sales/fetcher";
+import { getRandomColors } from "../utils";
+
+export default function useChart() {
+  const query = useQuery({ queryKey: ["sales"], queryFn: listSales });
+
+  const monthString = [
+    "Januari",
+    "Februari",
+    "Maret",
+    "April",
+    "Mei",
+    "Juni",
+    "Juli",
+    "Agustus",
+    "September",
+    "Oktober",
+    "November",
+    "Desember",
+  ];
+
+  const data = query.data?.data || [];
+
+  function getSalesYears() {
+    if (data.length > 0) {
+      const sortedSales = data.sort((a, b) => {
+        const dateA = new Date(a.tgl);
+        const dateB = new Date(b.tgl);
+
+        if (dateA < dateB) return -1;
+        if (dateA > dateB) return 1;
+
+        return 0;
+      });
+
+      const firstYears = new Date(sortedSales[0].tgl).getFullYear();
+      const lastYears = new Date(
+        sortedSales[sortedSales.length - 1].tgl
+      ).getFullYear();
+
+      return {
+        first: firstYears,
+        last: lastYears,
+      };
+    }
+  }
+
+  function getYearsArray() {
+    const date = getSalesYears();
+
+    if (date) {
+      const years = Array.from({ length: date.last - date.first + 1 }).map(
+        (_, i) => date.first + i
+      );
+
+      return years;
+    }
+
+    return [];
+  }
+
+  function getSalesByYearsAndMonths() {
+    const months = Array.from({ length: monthString.length }).map((_, i) => i);
+    const years = getYearsArray();
+
+    const dataSets: {
+      [months: string]: {
+        [years: number]: number;
+      };
+    } = {};
+
+    years.forEach((year) => {
+      months.forEach((month) => {
+        const sales = data
+          .filter((sale) => {
+            const salesDate = new Date(sale.tgl);
+            const salesMonth = salesDate.getMonth();
+            const salesYears = salesDate.getFullYear();
+
+            return salesMonth === month && salesYears === year;
+          })
+          .reduce((a, b) => a + b.total_bayar, 0);
+
+        if (dataSets[monthString[month]]) {
+          if (!dataSets[monthString[month]][year]) {
+            dataSets[monthString[month]][year] = sales;
+          } else {
+            dataSets[monthString[month]][year] += sales;
+          }
+        } else {
+          dataSets[monthString[month]] = {
+            [year]: sales,
+          };
+        }
+      });
+    });
+
+    return dataSets;
+  }
+
+  const sales = getSalesByYearsAndMonths();
+
+  const salesKeys = Object.keys(sales);
+
+  const chartData = salesKeys.map((key) => ({
+    month: key,
+    ...sales[key],
+  }));
+
+  const chartConfig: {
+    [key: string]: {
+      label: string;
+      color: string;
+    };
+  } = {} satisfies ChartConfig;
+
+  const years = getYearsArray();
+
+  years.forEach((year) => {
+    if (!chartConfig[year]) {
+      chartConfig[year] = {
+        label: year.toString(),
+        color: getRandomColors(),
+      };
+    }
+  });
+
+  return {
+    data: chartData,
+    config: chartConfig,
+    years: years,
+  };
+}

--- a/frontend/src/lib/hooks/useSales.ts
+++ b/frontend/src/lib/hooks/useSales.ts
@@ -263,7 +263,7 @@ export function useSales({
         title: "Data berhasil disimpan",
         description: response.message.join(", "),
       });
-      router.refresh();
+      router.replace("/sales");
       onReset();
     } else {
       toast({

--- a/frontend/src/lib/hooks/useSalesData.ts
+++ b/frontend/src/lib/hooks/useSalesData.ts
@@ -1,9 +1,11 @@
 "use client";
 
+import { useQuery } from "@tanstack/react-query";
 import { format } from "date-fns";
 import React from "react";
 import { DateRange } from "react-day-picker";
 import { TSales } from "../api/sales/definitions";
+import { listSales } from "../api/sales/fetcher";
 
 export type TSalesDataHook = {
   state: {
@@ -11,6 +13,9 @@ export type TSalesDataHook = {
     currentSort: TSalesSortOptions;
     dates: DateRange | undefined;
     grandTotal: number;
+
+    isLoading: boolean;
+    error: Error | null;
   };
 
   handler: {
@@ -27,11 +32,7 @@ export type TSalesSortOptions = {
   order: "asc" | "desc";
 };
 
-export default function useSalesData({
-  salesData,
-}: {
-  salesData: TSales[];
-}): TSalesDataHook {
+export default function useSalesData(): TSalesDataHook {
   const [search, setSearch] = React.useState<string>("");
   const [sortOptions, setSortOptions] = React.useState<TSalesSortOptions>({
     by: "kode",
@@ -41,6 +42,13 @@ export default function useSalesData({
     from: undefined,
     to: undefined,
   });
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["sales"],
+    queryFn: listSales,
+  });
+
+  const salesData = data?.data || [];
 
   function calculateTotalBarang(sale: TSales) {
     return sale.sales_detail.map((item) => item.barang).length;
@@ -130,6 +138,8 @@ export default function useSalesData({
       currentSort: sortOptions,
       dates,
       grandTotal: calculateGrandTotal(),
+      isLoading,
+      error,
     },
     handler: {
       calculateTotalBarang,

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,6 +1,10 @@
-import { type ClassValue, clsx } from "clsx"
-import { twMerge } from "tailwind-merge"
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+  return twMerge(clsx(inputs));
+}
+
+export function getRandomColors() {
+  return `#${Math.floor(Math.random() * 16777215).toString(16)}`;
 }


### PR DESCRIPTION
Finally successfully implemented the dashboard page and components 🚀 

The Dashboard page contains 3 key pieces of information: Sales (Transaksi), Products (Barang) and Customers.  
I used the `shadcn-ui` chart component to visualize the statistics of the sales data. Then I used a card style for the products and customer data.

The successful implementation of the `shadcn-ui` for the sales data was a huge relief for me. But, obviously, checking for 🐛 is never going to be stopped.

Cheers.